### PR TITLE
Fix compile issues in Forward classes

### DIFF
--- a/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/config/ForwardConfig.java
+++ b/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/config/ForwardConfig.java
@@ -33,7 +33,7 @@ public class ForwardConfig {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) TimeUnit.SECONDS.toMillis(timeoutSeconds))
                 .responseTimeout(Duration.ofSeconds(timeoutSeconds))
-                .doOnConnected(conn -> conn.addHandlerLast(new ReadTimeoutHandler(timeoutSeconds)));
+                .doOnConnected(conn -> conn.addHandlerLast(new ReadTimeoutHandler(timeoutSeconds, TimeUnit.SECONDS)));
         return WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .build();

--- a/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/controller/ForwardController.java
+++ b/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/controller/ForwardController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -80,7 +81,7 @@ public class ForwardController {
         return ResponseEntity.status(status).body(buildErrorMap(message, status));
     }
 
-    private Map<String, Object> buildErrorMap(String message, HttpStatus status) {
+    private Map<String, Object> buildErrorMap(String message, HttpStatusCode status) {
         Map<String, Object> body = new HashMap<>();
         body.put("error", message);
         body.put("status", status.value());


### PR DESCRIPTION
## Summary
- fix constructor usage for `ReadTimeoutHandler`
- allow `buildErrorMap` to accept `HttpStatusCode` so `ForwardController` compiles with Spring 6

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6870a296b54883338e28b1b464ea6fa6