### PR TITLE
Implement 6-digit password reset flow

### DIFF
--- a/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/JwtAuthenticatorApplication.java
+++ b/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/JwtAuthenticatorApplication.java
@@ -5,9 +5,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAspectJAutoProxy
+@EnableScheduling
 public class JwtAuthenticatorApplication extends SpringBootServletInitializer {
 
     @Override

--- a/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/controller/AuthController.java
+++ b/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/controller/AuthController.java
@@ -447,6 +447,27 @@ public class AuthController {
         }
     }
 
+    // Forgot Password using userId and email
+    @PostMapping("/forgot-password")
+    public ResponseEntity<?> forgotPassword(@Valid @RequestBody ForgotPasswordCodeRequest request) {
+        try {
+            String result = authService.sendPasswordResetCode(request);
+            return ResponseEntity.ok(Map.of("message", result));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("message", e.getMessage()));
+        }
+    }
+
+    // Verify code using userId and email
+    @PostMapping("/verify-code")
+    public ResponseEntity<?> verifyCode(@Valid @RequestBody VerifyCodeWithUserRequest request) {
+        String result = authService.verifyResetCode(request);
+        if (result.startsWith("Invalid") || result.startsWith("Verification code has expired")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("message", result));
+        }
+        return ResponseEntity.ok(Map.of("message", result));
+    }
+
     // Enhanced Forgot Password - Send Verification Code
     @PostMapping("/forgot-password-code")
     @Operation(summary = "Send password reset verification code", description = "Send a verification code to the user's email for password reset")

--- a/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/dto/ForgotPasswordCodeRequest.java
+++ b/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/dto/ForgotPasswordCodeRequest.java
@@ -1,0 +1,17 @@
+package com.example.jwtauthenticator.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "Forgot password request using userId and email")
+public record ForgotPasswordCodeRequest(
+    @Schema(description = "User ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    @NotBlank(message = "User ID is required")
+    String userId,
+
+    @Schema(description = "Email address", example = "user@example.com")
+    @Email(message = "Invalid email format")
+    @NotBlank(message = "Email is required")
+    String email
+) {}

--- a/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/dto/VerifyCodeWithUserRequest.java
+++ b/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/dto/VerifyCodeWithUserRequest.java
@@ -1,0 +1,21 @@
+package com.example.jwtauthenticator.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "Verify password reset code using userId and email")
+public record VerifyCodeWithUserRequest(
+    @Schema(description = "User ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    @NotBlank(message = "User ID is required")
+    String userId,
+
+    @Schema(description = "Email address", example = "user@example.com")
+    @Email(message = "Invalid email format")
+    @NotBlank(message = "Email is required")
+    String email,
+
+    @Schema(description = "Verification code", example = "123456")
+    @NotBlank(message = "Verification code is required")
+    String code
+) {}

--- a/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/entity/PasswordResetCode.java
+++ b/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/entity/PasswordResetCode.java
@@ -41,7 +41,7 @@ public class PasswordResetCode {
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
-        expiresAt = LocalDateTime.now().plusMinutes(15); // Code expires in 15 minutes
+        expiresAt = LocalDateTime.now().plusMinutes(10); // Code expires in 10 minutes
         used = false;
     }
 

--- a/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/service/EmailService.java
+++ b/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/service/EmailService.java
@@ -67,4 +67,17 @@ public class EmailService {
             
         sendEmail(to, subject, emailBody);
     }
+
+    /**
+     * Send a 6-digit verification code for password reset.
+     *
+     * @param to   recipient email
+     * @param code 6-digit verification code
+     */
+    public void sendPasswordResetCodeEmail(String to, String code) {
+        String subject = "Password Reset Verification Code";
+        String emailBody = "Your verification code is: " + code +
+                ". It will expire in 10 minutes. Use this code to reset your password.";
+        sendEmail(to, subject, emailBody);
+    }
 }

--- a/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/service/PasswordResetCodeCleanupScheduler.java
+++ b/JWT_Authenticator_Project/src/main/java/com/example/jwtauthenticator/service/PasswordResetCodeCleanupScheduler.java
@@ -1,0 +1,17 @@
+package com.example.jwtauthenticator.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PasswordResetCodeCleanupScheduler {
+
+    private final AuthService authService;
+
+    @Scheduled(fixedRate = 300000) // every 5 minutes
+    public void cleanupExpiredCodes() {
+        authService.cleanupExpiredCodes();
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs for forgot password and verification with userId+email
- email users a 6-digit verification code
- expire codes after 10 minutes and clean up periodically
- support `/auth/forgot-password` and `/auth/verify-code` endpoints
- enable scheduling for cleanup jobs

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687179b08bf083338a6defcddc15840d