### PR TITLE
Update reset workflow docs and Postman collection

### DIFF
--- a/JWT_Authenticator_Project/JWT_Authenticator_Complete_Collection.json
+++ b/JWT_Authenticator_Project/JWT_Authenticator_Complete_Collection.json
@@ -4,7 +4,7 @@
     "name": "JWT Authenticator API - Complete Collection",
     "description": "Complete API collection for JWT Authenticator microservice with authentication, 2FA, password reset, request forwarding, ID generation, and more.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "version": "2.0.0"
+    "version": "2.1.0"
   },
   "item": [
     {
@@ -406,6 +406,87 @@
               ]
             },
             "description": "Request password reset email"
+          }
+        },
+        {
+          "name": "Forgot Password Code",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"email\": \"{{testEmail}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/forgot-password-code",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "forgot-password-code"
+              ]
+            },
+            "description": "Send verification code for password reset"
+          }
+        },
+        {
+          "name": "Verify Reset Code",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"email\": \"{{testEmail}}\",\n    \"code\": \"{{resetCode}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/verify-reset-code",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "verify-reset-code"
+              ]
+            },
+            "description": "Verify password reset code"
+          }
+        },
+        {
+          "name": "Set New Password",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+                "raw": "{\n    \"email\": \"{{testEmail}}\",\n    \"code\": \"{{resetCode}}\",\n    \"newPassword\": \"NewSecurePassword123!\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/set-new-password",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "auth",
+                "set-new-password"
+              ]
+            },
+            "description": "Reset password using verification code"
           }
         },
         {

--- a/JWT_Authenticator_Project/JWT_Authenticator_Complete_Environment.json
+++ b/JWT_Authenticator_Project/JWT_Authenticator_Complete_Environment.json
@@ -88,6 +88,12 @@
       "enabled": true
     },
     {
+      "key": "resetCode",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
       "key": "googleIdToken",
       "value": "",
       "type": "secret",

--- a/JWT_Authenticator_Project/PROJECT_EXECUTION_GUIDE.md
+++ b/JWT_Authenticator_Project/PROJECT_EXECUTION_GUIDE.md
@@ -63,6 +63,27 @@ To use Google Sign-In:
 - Multi-tenant architecture ensures data isolation
 - Two-factor authentication adds an extra layer of security
 
+## Endpoint Authentication Requirements
+
+| Endpoint | Authentication | Type |
+| --- | --- | --- |
+| `POST /auth/register` | Not required | - |
+| `POST /auth/token` | Not required | - |
+| `POST /auth/login` | Not required | - |
+| `POST /auth/login/username` | Not required | - |
+| `POST /auth/login/email` | Not required | - |
+| `POST /auth/refresh` | Not required (requires refresh token body) | - |
+| `PUT /auth/profile` | Required | Bearer token & `X-Brand-Id` |
+| `POST /auth/check-email` | Not required | - |
+| `POST /auth/forgot-password` | Not required | - |
+| `POST /auth/forgot-password-code` | Not required | - |
+| `POST /auth/verify-reset-code` | Not required | - |
+| `POST /auth/set-new-password` | Not required | - |
+| `GET /api/protected` | Required | Bearer token & `X-Brand-Id` |
+| `POST /forward` | Required | Bearer token & `X-Brand-Id` |
+| `POST /api/id-generator/generate` | Not required | - |
+| `POST /api/id-generator/generate/{prefix}` | Not required | - |
+
 ## API Documentation
 - Swagger UI: http://localhost:8080/swagger-ui.html
 - API Docs: http://localhost:8080/v3/api-docs


### PR DESCRIPTION
## Summary
- extend Postman collection with reset-code workflow
- store resetCode in environment
- document authentication requirements in execution guide

## Testing
- `python3 -m json.tool JWT_Authenticator_Complete_Collection.json`
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6871800123f08333a645b087fb9bde1e